### PR TITLE
add luasec

### DIFF
--- a/luasec/https.lua
+++ b/luasec/https.lua
@@ -1,0 +1,146 @@
+----------------------------------------------------------------------------
+-- LuaSec 1.0.2
+-- Copyright (C) 2009-2021 PUC-Rio
+--
+-- Author: Pablo Musa
+-- Author: Tomas Guisasola
+---------------------------------------------------------------------------
+
+local socket = require("socket")
+local ssl    = require("Zenitha.luasec.ssl")
+local ltn12  = require("ltn12")
+local http   = require("socket.http")
+local url    = require("socket.url")
+
+local try    = socket.try
+
+--
+-- Module
+--
+local _M = {
+  _VERSION   = "1.0.2",
+  _COPYRIGHT = "LuaSec 1.0.2 - Copyright (C) 2009-2021 PUC-Rio",
+  PORT       = 443,
+  TIMEOUT    = 60
+}
+
+-- TLS configuration
+local cfg = {
+  protocol = "any",
+  options  = {"all", "no_sslv2", "no_sslv3", "no_tlsv1"},
+  verify   = "none",
+}
+
+--------------------------------------------------------------------
+-- Auxiliar Functions
+--------------------------------------------------------------------
+
+-- Insert default HTTPS port.
+local function default_https_port(u)
+   return url.build(url.parse(u, {port = _M.PORT}))
+end
+
+-- Convert an URL to a table according to Luasocket needs.
+local function urlstring_totable(url, body, result_table)
+   url = {
+      url = default_https_port(url),
+      method = body and "POST" or "GET",
+      sink = ltn12.sink.table(result_table)
+   }
+   if body then
+      url.source = ltn12.source.string(body)
+      url.headers = {
+         ["content-length"] = #body,
+         ["content-type"] = "application/x-www-form-urlencoded",
+      }
+   end
+   return url
+end
+
+-- Forward calls to the real connection object.
+local function reg(conn)
+   local mt = getmetatable(conn.sock).__index
+   for name, method in pairs(mt) do
+      if type(method) == "function" then
+         conn[name] = function (self, ...)
+                         return method(self.sock, ...)
+                      end
+      end
+   end
+end
+
+-- Return a function which performs the SSL/TLS connection.
+local function tcp(params)
+   params = params or {}
+   -- Default settings
+   for k, v in pairs(cfg) do 
+      params[k] = params[k] or v
+   end
+   -- Force client mode
+   params.mode = "client"
+   -- 'create' function for LuaSocket
+   return function ()
+      local conn = {}
+      conn.sock = try(socket.tcp())
+      local st = getmetatable(conn.sock).__index.settimeout
+      function conn:settimeout(...)
+         return st(self.sock, _M.TIMEOUT)
+      end
+      -- Replace TCP's connection function
+      function conn:connect(host, port)
+         try(self.sock:connect(host, port))
+         self.sock = try(ssl.wrap(self.sock, params))
+         self.sock:sni(host)
+         self.sock:settimeout(_M.TIMEOUT)
+         try(self.sock:dohandshake())
+         reg(self, getmetatable(self.sock))
+         return 1
+      end
+      return conn
+  end
+end
+
+--------------------------------------------------------------------
+-- Main Function
+--------------------------------------------------------------------
+
+-- Make a HTTP request over secure connection.  This function receives
+--  the same parameters of LuaSocket's HTTP module (except 'proxy' and
+--  'redirect') plus LuaSec parameters.
+--
+-- @param url mandatory (string or table)
+-- @param body optional (string)
+-- @return (string if url == string or 1), code, headers, status
+--
+local function request(url, body)
+  local result_table = {}
+  local stringrequest = type(url) == "string"
+  if stringrequest then
+    url = urlstring_totable(url, body, result_table)
+  else
+    url.url = default_https_port(url.url)
+  end
+  if http.PROXY or url.proxy then
+    return nil, "proxy not supported"
+  elseif url.redirect then
+    return nil, "redirect not supported"
+  elseif url.create then
+    return nil, "create function not permitted"
+  end
+  -- New 'create' function to establish a secure connection
+  url.create = tcp(url)
+  local res, code, headers, status = http.request(url)
+  if res and stringrequest then
+    return table.concat(result_table), code, headers, status
+  end
+  return res, code, headers, status
+end
+
+--------------------------------------------------------------------------------
+-- Export module
+--
+
+_M.request = request
+_M.tcp = tcp
+
+return _M

--- a/luasec/options.lua
+++ b/luasec/options.lua
@@ -1,0 +1,93 @@
+local function usage()
+  print("Usage:")
+  print("* Generate options of your system:")
+  print("  lua options.lua -g /path/to/ssl.h [version] > options.c")
+  print("* Examples:")
+  print("  lua options.lua -g /usr/include/openssl/ssl.h > options.c\n")
+  print("  lua options.lua -g /usr/include/openssl/ssl.h \"OpenSSL 1.1.1f\" > options.c\n")
+
+  print("* List options of your system:")
+  print("  lua options.lua -l /path/to/ssl.h\n")
+end
+
+--
+local function printf(str, ...)
+  print(string.format(str, ...))
+end
+
+local function generate(options, version)
+  print([[
+/*--------------------------------------------------------------------------
+ * LuaSec 1.1.1
+ *
+ * Copyright (C) 2006-2021 Bruno Silvestre
+ *
+ *--------------------------------------------------------------------------*/
+
+#include <openssl/ssl.h>
+
+#include "options.h"
+
+/* If you need to generate these options again, see options.lua */
+
+]])
+
+  printf([[
+/* 
+  OpenSSL version: %s
+*/
+]], version)
+
+  print([[static lsec_ssl_option_t ssl_options[] = {]])
+
+  for k, option in ipairs(options) do
+    local name = string.lower(string.sub(option, 8))
+    print(string.format([[#if defined(%s)]], option))
+    print(string.format([[  {"%s", %s},]], name, option))
+    print([[#endif]])
+  end
+  print([[  {NULL, 0L}]])
+  print([[
+};
+
+LSEC_API lsec_ssl_option_t* lsec_get_ssl_options() {
+  return ssl_options;
+}
+]])
+end
+
+local function loadoptions(file)
+  local options = {}
+  local f = assert(io.open(file, "r"))
+  for line in f:lines() do
+    local op = string.match(line, "define%s+(SSL_OP_BIT%()")
+    if not op then
+      op = string.match(line, "define%s+(SSL_OP_%S+)")
+      if op then
+        table.insert(options, op)
+      end
+    end
+  end
+  table.sort(options, function(a,b) return a<b end)
+  return options
+end
+--
+
+local options
+local flag, file, version = ...
+
+version = version or "Unknown"
+
+if not file then
+  usage()
+elseif flag == "-g" then
+  options = loadoptions(file)
+  generate(options, version)
+elseif flag == "-l" then
+  options = loadoptions(file)
+  for k, option in ipairs(options) do
+    print(option)
+  end
+else
+  usage()
+end

--- a/luasec/ssl.lua
+++ b/luasec/ssl.lua
@@ -1,0 +1,282 @@
+------------------------------------------------------------------------------
+-- LuaSec 1.0.2
+--
+-- Copyright (C) 2006-2021 Bruno Silvestre
+--
+------------------------------------------------------------------------------
+
+local core    = require("ssl.core")
+local context = require("ssl.context")
+local x509    = require("ssl.x509")
+local config  = require("ssl.config")
+
+local unpack  = table.unpack or unpack
+
+-- We must prevent the contexts to be collected before the connections,
+-- otherwise the C registry will be cleared.
+local registry = setmetatable({}, {__mode="k"})
+
+--
+--
+--
+local function optexec(func, param, ctx)
+  if param then
+    if type(param) == "table" then
+      return func(ctx, unpack(param))
+    else
+      return func(ctx, param)
+    end
+  end
+  return true
+end
+
+--
+-- Convert an array of strings to wire-format
+--
+local function array2wireformat(array)
+   local str = ""
+   for k, v in ipairs(array) do
+      if type(v) ~= "string" then return nil end
+      local len = #v
+      if len == 0 then
+        return nil, "invalid ALPN name (empty string)"
+      elseif len > 255 then
+        return nil, "invalid ALPN name (length > 255)"
+      end
+      str = str .. string.char(len) .. v
+   end
+   if str == "" then return nil, "invalid ALPN list (empty)" end
+   return str
+end
+
+--
+-- Convert wire-string format to array
+--
+local function wireformat2array(str)
+   local i = 1
+   local array = {}
+   while i < #str do
+      local len = str:byte(i)
+      array[#array + 1] = str:sub(i + 1, i + len)
+      i = i + len + 1
+   end
+   return array
+end
+
+--
+--
+--
+local function newcontext(cfg)
+   local succ, msg, ctx
+   -- Create the context
+   ctx, msg = context.create(cfg.protocol)
+   if not ctx then return nil, msg end
+   -- Mode
+   succ, msg = context.setmode(ctx, cfg.mode)
+   if not succ then return nil, msg end
+   local certificates = cfg.certificates
+   if not certificates then
+      certificates = {
+         { certificate = cfg.certificate, key = cfg.key, password = cfg.password }
+      }
+   end
+   for _, certificate in ipairs(certificates) do
+      -- Load the key
+      if certificate.key then
+         if certificate.password and
+            type(certificate.password) ~= "function" and
+            type(certificate.password) ~= "string"
+         then
+            return nil, "invalid password type"
+         end
+         succ, msg = context.loadkey(ctx, certificate.key, certificate.password)
+         if not succ then return nil, msg end
+      end
+      -- Load the certificate(s)
+      if certificate.certificate then
+        succ, msg = context.loadcert(ctx, certificate.certificate)
+        if not succ then return nil, msg end
+        if certificate.key and context.checkkey then
+          succ = context.checkkey(ctx)
+          if not succ then return nil, "private key does not match public key" end
+        end
+      end
+   end
+   -- Load the CA certificates
+   if cfg.cafile or cfg.capath then
+      succ, msg = context.locations(ctx, cfg.cafile, cfg.capath)
+      if not succ then return nil, msg end
+   end
+   -- Set SSL ciphers
+   if cfg.ciphers then
+      succ, msg = context.setcipher(ctx, cfg.ciphers)
+      if not succ then return nil, msg end
+   end
+   -- Set SSL cipher suites
+   if cfg.ciphersuites then
+      succ, msg = context.setciphersuites(ctx, cfg.ciphersuites)
+      if not succ then return nil, msg end
+   end
+    -- Set the verification options
+   succ, msg = optexec(context.setverify, cfg.verify, ctx)
+   if not succ then return nil, msg end
+   -- Set SSL options
+   succ, msg = optexec(context.setoptions, cfg.options, ctx)
+   if not succ then return nil, msg end
+   -- Set the depth for certificate verification
+   if cfg.depth then
+      succ, msg = context.setdepth(ctx, cfg.depth)
+      if not succ then return nil, msg end
+   end
+
+   -- NOTE: Setting DH parameters and elliptic curves needs to come after
+   -- setoptions(), in case the user has specified the single_{dh,ecdh}_use
+   -- options.
+
+   -- Set DH parameters
+   if cfg.dhparam then
+      if type(cfg.dhparam) ~= "function" then
+         return nil, "invalid DH parameter type"
+      end
+      context.setdhparam(ctx, cfg.dhparam)
+   end
+   
+   -- Set elliptic curves
+   if (not config.algorithms.ec) and (cfg.curve or cfg.curveslist) then
+     return false, "elliptic curves not supported"
+   end
+   if config.capabilities.curves_list and cfg.curveslist then
+     succ, msg = context.setcurveslist(ctx, cfg.curveslist)
+     if not succ then return nil, msg end
+   elseif cfg.curve then
+     succ, msg = context.setcurve(ctx, cfg.curve)
+     if not succ then return nil, msg end
+   end
+
+   -- Set extra verification options
+   if cfg.verifyext and ctx.setverifyext then
+      succ, msg = optexec(ctx.setverifyext, cfg.verifyext, ctx)
+      if not succ then return nil, msg end
+   end
+
+   -- ALPN
+   if cfg.mode == "server" and cfg.alpn then
+      if type(cfg.alpn) == "function" then
+         local alpncb = cfg.alpn
+         -- This callback function has to return one value only
+         succ, msg = context.setalpncb(ctx, function(str)
+            local protocols = alpncb(wireformat2array(str))
+            if type(protocols) == "string" then
+               protocols = { protocols }
+            elseif type(protocols) ~= "table" then
+               return nil
+            end
+            return (array2wireformat(protocols))    -- use "()" to drop error message
+         end)
+         if not succ then return nil, msg end
+      elseif type(cfg.alpn) == "table" then
+         local protocols = cfg.alpn
+         -- check if array is valid before use it
+         succ, msg = array2wireformat(protocols)
+         if not succ then return nil, msg end
+         -- This callback function has to return one value only
+         succ, msg = context.setalpncb(ctx, function()
+            return (array2wireformat(protocols))    -- use "()" to drop error message
+         end)
+         if not succ then return nil, msg end
+      else
+         return nil, "invalid ALPN parameter"
+      end
+   elseif cfg.mode == "client" and cfg.alpn then
+      local alpn
+      if type(cfg.alpn) == "string" then
+         alpn, msg = array2wireformat({ cfg.alpn })
+      elseif type(cfg.alpn) == "table" then
+         alpn, msg = array2wireformat(cfg.alpn)
+      else
+         return nil, "invalid ALPN parameter"
+      end
+      if not alpn then return nil, msg end
+      succ, msg = context.setalpn(ctx, alpn)
+      if not succ then return nil, msg end
+   end
+
+   if config.capabilities.dane and cfg.dane then
+      context.setdane(ctx)
+   end
+
+   return ctx
+end
+
+--
+--
+--
+local function wrap(sock, cfg)
+   local ctx, msg
+   if type(cfg) == "table" then
+      ctx, msg = newcontext(cfg)
+      if not ctx then return nil, msg end
+   else
+      ctx = cfg
+   end
+   local s, msg = core.create(ctx)
+   if s then
+      core.setfd(s, sock:getfd())
+      sock:setfd(core.SOCKET_INVALID)
+      registry[s] = ctx
+      return s
+   end
+   return nil, msg 
+end
+
+--
+-- Extract connection information.
+--
+local function info(ssl, field)
+  local str, comp, err, protocol
+  comp, err = core.compression(ssl)
+  if err then
+    return comp, err
+  end
+  -- Avoid parser
+  if field == "compression" then
+    return comp
+  end
+  local info = {compression = comp}
+  str, info.bits, info.algbits, protocol = core.info(ssl)
+  if str then
+    info.cipher, info.protocol, info.key,
+    info.authentication, info.encryption, info.mac =
+        string.match(str, 
+          "^(%S+)%s+(%S+)%s+Kx=(%S+)%s+Au=(%S+)%s+Enc=(%S+)%s+Mac=(%S+)")
+    info.export = (string.match(str, "%sexport%s*$") ~= nil)
+  end
+  if protocol then
+    info.protocol = protocol
+  end
+  if field then
+    return info[field]
+  end
+  -- Empty?
+  return ( (next(info)) and info )
+end
+
+--
+-- Set method for SSL connections.
+--
+core.setmethod("info", info)
+
+--------------------------------------------------------------------------------
+-- Export module
+--
+
+local _M = {
+  _VERSION        = "1.0.2",
+  _COPYRIGHT      = core.copyright(),
+  config          = config,
+  loadcertificate = x509.load,
+  newcontext      = newcontext,
+  wrap            = wrap,
+}
+
+return _M


### PR DESCRIPTION
demo

```lua
function love.run()
    print('love.run()')
    local https = require('Zenitha.luasec.https')
    local ssl = require('Zenitha.luasec.ssl')
    local socket = require('socket')

    ---------------------------------------------------------------------------
    -- https
    print(https.request('https://localhost:443'))

    ---------------------------------------------------------------------------
    -- tls
    local body = '' ..
        'GET / HTTP/1.1\r\n' ..
        'Host: localhost:443\r\n\r\n'

    local params = {
        mode = 'client',
        protocol = 'any',
    }
    local conn = socket.tcp()
    conn:connect('localhost', 443)
    -- TLS/SSL initialization
    conn = ssl.wrap(conn, params)
    conn:dohandshake()
    --
    conn:send(body)
    print(conn:receive('*l'))
    conn:close()
end
```

以上代码已测试可用

至于websocket，把下面的代码放到tcp握手之后，websocket握手之前，就好了

```lua
    -- TLS/SSL initialization
    conn = ssl.wrap(conn, params)
    conn:dohandshake()
```

还有一个问题是，我只能保证同步的websocket程序中能用。

具体原因是我不确定luasec是否支持异步，他可能没考虑。一种可能的结果是localhost没事，远程延迟导致ssl握手炸了。